### PR TITLE
feat: Implement PDF generation with custom cover page

### DIFF
--- a/carmel-pdf-generator/src/components/ReportForm.tsx
+++ b/carmel-pdf-generator/src/components/ReportForm.tsx
@@ -36,8 +36,12 @@ const ReportForm = () => {
       a.click();
       a.remove();
       window.URL.revokeObjectURL(url);
-    } catch (err: any) {
-      setError(err.message);
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError('An unknown error occurred');
+      }
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
This commit introduces a new Next.js application that allows users to generate a PDF document with a personalized cover page.

The application features:
- A web form to collect user details (name, register number, etc.).
- A Next.js API route that uses the `pdf-lib` library to merge the user's data with a cover page template.
- The ability to download the final, merged PDF document.

Also includes a fix for a TypeScript linting error (`no-explicit-any`) in the form submission handler.