### PR TITLE
feat: Implement PDF generation with custom cover page

### DIFF
--- a/carmel-pdf-generator/src/app/api/generate-pdf/route.ts
+++ b/carmel-pdf-generator/src/app/api/generate-pdf/route.ts
@@ -66,8 +66,9 @@ export async function POST(req: NextRequest) {
     }
 
     const pdfBytes = await pdfDoc.save();
+    const pdfBuffer = Buffer.from(pdfBytes);
 
-    return new NextResponse(pdfBytes, {
+    return new NextResponse(pdfBuffer, {
       status: 200,
       headers: {
         'Content-Type': 'application/pdf',


### PR DESCRIPTION
This commit introduces a new Next.js application that allows users to generate a PDF document with a personalized cover page.

The application features:
- A web form to collect user details (name, register number, etc.).
- A Next.js API route that uses the `pdf-lib` library to merge the user's data with a cover page template.
- The ability to download the final, merged PDF document.

This commit also includes the following fixes:
- Corrected a TypeScript linting error (`no-explicit-any`) in the form submission handler.
- Fixed a build error by converting the `Uint8Array` from `pdf-lib` to a `Buffer` for the `NextResponse`.