### PR TITLE
feat: Implement PDF generation with custom cover page

### DIFF
--- a/carmel-pdf-generator/src/app/api/generate-pdf/route.ts
+++ b/carmel-pdf-generator/src/app/api/generate-pdf/route.ts
@@ -12,8 +12,8 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
     }
 
-    const coverPath = path.resolve('./public', 'cover_template.pdf');
-    const reportPath = path.resolve('./public', 'main_report.pdf');
+    const coverPath = path.join(process.cwd(), 'public', 'cover_template.pdf');
+    const reportPath = path.join(process.cwd(), 'public', 'main_report.pdf');
 
     const coverBytes = await fs.readFile(coverPath);
     const reportBytes = await fs.readFile(reportPath);


### PR DESCRIPTION
This commit introduces a new Next.js application that allows users to generate a PDF document with a personalized cover page.

The application features:
- A web form to collect user details (name, register number, etc.).
- A Next.js API route that uses the `pdf-lib` library to merge the user's data with a cover page template.
- The ability to download the final, merged PDF document.

This commit also includes the following fixes:
- Corrected a TypeScript linting error (`no-explicit-any`) in the form submission handler.
- Fixed a build error by converting the `Uint8Array` from `pdf-lib` to a `Buffer` for the `NextResponse`.
- Fixed a 500 server error by using `path.join(process.cwd(), ...)` to reliably locate the PDF files in the `public` directory from the API route.