### PR TITLE
feat: Add analytics and admin panel

### DIFF
--- a/carmel-pdf-generator/src/app/api/analytics/route.ts
+++ b/carmel-pdf-generator/src/app/api/analytics/route.ts
@@ -8,7 +8,7 @@ export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
     const { deviceName, androidVersion, formData } = body;
-    const ip = req.ip ?? req.headers.get('x-forwarded-for') ?? 'unknown';
+    const ip = req.headers.get('x-forwarded-for') ?? 'unknown';
 
     let analyticsData = [];
     try {


### PR DESCRIPTION
This commit introduces an analytics feature to the website.

- A new API endpoint `/api/analytics` is created to log user IP, device name, Android version, and form data to a JSON file.
- The frontend is updated to send analytics data on form submission.
- A new admin panel is available at `/admin` to display the collected analytics data.
- The admin panel is protected by basic authentication, with credentials stored in environment variables.